### PR TITLE
fix condition in register

### DIFF
--- a/cytoscape-node-resize.js
+++ b/cytoscape-node-resize.js
@@ -719,7 +719,7 @@
         });
     }
 
-    if (typeof cytoscape !== 'undefined' || typeof jQuery !== "undefined" || typeof oCanvas !== "undefined") { // expose to global cytoscape (i.e. window.cytoscape)
+    if (typeof cytoscape !== 'undefined' && typeof jQuery !== "undefined" && typeof oCanvas !== "undefined") { // expose to global cytoscape (i.e. window.cytoscape)
         register(cytoscape, jQuery, oCanvas);
     }
 


### PR DESCRIPTION
The condition of registering is not correct.
That will be executed even if only one of cytoscape, jQuery and oCanvas is defined and cause undefined error.