### PR TITLE
Replace ocanvas, refactoring and performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Only consists of initilization & default options.
 
  * Cytoscape.js ^2.7.0
  * jquery ^1.7.0 || ^2.0.0 || ^3.0.0
- * oCanvas ^2.8.0 // It is not commonjs nor AMD compatible just include it in your html file
+ * konva ^1.6.3
  * cytoscape-undo-redo ^1.0.10 (optional)
 
 
@@ -87,7 +87,7 @@ CommonJS:
 var cytoscape = require('cytoscape');
 var nodeResize = require('cytoscape-node-resize');
 
-nodeResize( cytoscape, jQuery ); // register extension
+nodeResize( cytoscape, jQuery, Konva ); // register extension
 ```
 
 AMD:

--- a/cytoscape-node-resize.js
+++ b/cytoscape-node-resize.js
@@ -605,18 +605,22 @@
 
                         if (location.startsWith("top")) {
                             if (node.height() - xHeight > options.minHeight(node)) {
+                                // this will trigger a position event, leading to useless redraw.
+                                // TODO find a way to avoid that
                                 node.position("y", nodePos.y + xHeight / 2);
                                 options.setHeight(node, node.height() - xHeight);
                             } else if (isAspectedMode)
                                 return;
                         } else if (location.startsWith("bottom")) {
                             if (node.height() + xHeight > options.minHeight(node)) {
+                                // this will trigger a position event, leading to useless redraw.
                                 node.position("y", nodePos.y + xHeight / 2);
                                 options.setHeight(node, node.height() + xHeight);
                             } else if (isAspectedMode)
                                 return;
                         }
 
+                        // other position event triggered below
                         if (location.endsWith("left") && node.width() - xWidth > options.minWidth(node)) {
                             node.position("x", nodePos.x + xWidth / 2);
                             options.setWidth(node, node.width() - xWidth);
@@ -908,13 +912,16 @@
                 // listens for position event and refreshGrapples if necessary
                 cy.on("position", "node", ePositionNode = function(e) {
                     if(controls) {
+                        if(e.target.id() == controls.parent.id()) {
+                            controls.update();
+                        }
                         // if the position of compund changes by repositioning its children's
                         // Note: position event for compound is not triggered in this case
-                        if(currentPos.x != oldPos.x || currentPos.y != oldPos.y) {
+                        else if(currentPos.x != oldPos.x || currentPos.y != oldPos.y) {
                             currentPos = controls.parent.position();
+                            controls.update();
                             oldPos = {x : currentPos.x, y : currentPos.y};
                         }
-                        controls.update();
                     }
                 });
 

--- a/cytoscape-node-resize.js
+++ b/cytoscape-node-resize.js
@@ -373,7 +373,6 @@
                 this.grapples = [];
                 for(var i=0; i < grappleLocations.length; i++) {
                     var location = grappleLocations[i];
-                    console.log("create grapple", location);
                     var isActive = true;
                     if (options.isNoResizeMode(node) || (options.isFixedAspectRatioResizeMode(node) && location.indexOf("center") >= 0)) {
                         isActive = false;
@@ -425,8 +424,6 @@
                 // add the shape to the layer
                 canvas.add(rect);
                 this.shape = rect;
-
-                console.log(startPos, canvas, node.position());
             };
 
             BoundingRectangle.prototype.update = function () {
@@ -857,8 +854,7 @@
                 // declare old and current positions
                 var oldPos = {x: undefined, y: undefined};
                 var currentPos = {x : 0, y : 0};
-                cy.on("unselect", "node", eUnselectNode = function() {
-                    var node = this;
+                cy.on("unselect", "node", eUnselectNode = function(e) {
                     // reinitialize old and current compound positions
                     oldPos = {x: undefined, y: undefined};
                     currentPos = {x: 0, y: 0};
@@ -874,8 +870,8 @@
                     }
                 });
 
-                cy.on("select", "node", eSelectNode = function() {
-                    var node = this;
+                cy.on("select", "node", eSelectNode = function(e) {
+                    var node = e.target;
 
                     if(cy.nodes(':selected').size() == 1) {
                         controls = new ResizeControls(node);
@@ -888,31 +884,29 @@
                     }
                 });
 
-                cy.on("remove", "node", eRemoveNode = function() {
-                    var node = this;
+                cy.on("remove", "node", eRemoveNode = function(e) {
+                    var node = e.target;
                     // If a selected node is removed we should regard this event just like an unselect event
                     if ( node.selected() ) {
-                        eUnselectNode();
+                        eUnselectNode(e);
                     }
                 });
 
-                /*
                 // is this useful ? adding a node never seems to select it, and it causes a bug when changing parent
-                cy.on("add", "node", eAddNode = function() {
-                    var node = this;
+                cy.on("add", "node", eAddNode = function(e) {
+                    var node = e.target;
                     // If a selected node is added we should regard this event just like a select event
                     if ( node.selected() ) {
                         if(controls) {
                             controls.remove();
                             controls = null;
                         }
-                        eSelectNode();
+                        eSelectNode(e);
                     }
-                });*/
+                });
 
                 // listens for position event and refreshGrapples if necessary
-                cy.on("position", "node", ePositionNode = function() {
-                    var node = this;
+                cy.on("position", "node", ePositionNode = function(e) {
                     if(controls) {
                         // if the position of compund changes by repositioning its children's
                         // Note: position event for compound is not triggered in this case

--- a/cytoscape-node-resize.js
+++ b/cytoscape-node-resize.js
@@ -966,6 +966,10 @@
                     var node = this;
                     // If a selected node is added we should regard this event just like a select event
                     if ( node.selected() ) {
+                        if(controls) {
+                            controls.remove();
+                            controls = null;
+                        }
                         eSelectNode();
                     }
                 });

--- a/cytoscape-node-resize.js
+++ b/cytoscape-node-resize.js
@@ -962,7 +962,7 @@
                     }
                 });
 
-                cy.on("add", "node", eAddNode = function() {
+                /*cy.on("add", "node", eAddNode = function() {
                     var node = this;
                     // If a selected node is added we should regard this event just like a select event
                     if ( node.selected() ) {
@@ -972,7 +972,7 @@
                         }
                         eSelectNode();
                     }
-                });
+                });*/
 
                 // listens for position event and refreshGrapples if necessary
                 cy.on("position", "node", ePositionNode = function() {

--- a/cytoscape-node-resize.js
+++ b/cytoscape-node-resize.js
@@ -602,37 +602,47 @@
                         }
 
                         var nodePos = node.position();
+                        var newX = nodePos.x;
+                        var newY = nodePos.y;
+                        var isXresized = false;
+                        var isYresized = false;
 
                         if (location.startsWith("top")) {
                             if (node.height() - xHeight > options.minHeight(node)) {
-                                // this will trigger a position event, leading to useless redraw.
-                                // TODO find a way to avoid that
-                                node.position("y", nodePos.y + xHeight / 2);
+                                newY = nodePos.y + xHeight / 2;
+                                isYresized = true;
                                 options.setHeight(node, node.height() - xHeight);
                             } else if (isAspectedMode)
                                 return;
                         } else if (location.startsWith("bottom")) {
                             if (node.height() + xHeight > options.minHeight(node)) {
-                                // this will trigger a position event, leading to useless redraw.
-                                node.position("y", nodePos.y + xHeight / 2);
+                                newY = nodePos.y + xHeight / 2;
+                                isYresized = true;
                                 options.setHeight(node, node.height() + xHeight);
                             } else if (isAspectedMode)
                                 return;
                         }
 
-                        // other position event triggered below
                         if (location.endsWith("left") && node.width() - xWidth > options.minWidth(node)) {
-                            node.position("x", nodePos.x + xWidth / 2);
+                            newX = nodePos.x + xWidth / 2;
+                            isXresized = true;
                             options.setWidth(node, node.width() - xWidth);
                         } else if (location.endsWith("right") && node.width() + xWidth > options.minWidth(node)) {
-                            node.position("x", nodePos.x + xWidth / 2);
+                            newX = nodePos.x + xWidth / 2;
+                            isXresized = true;
                             options.setWidth(node, node.width() + xWidth);
+                        }
+
+                        // this will trigger a position event, leading to useless redraw.
+                        // TODO find a way to avoid that
+                        if(isXresized || isYresized) {
+                            node.position({x: newX, y: newY});
                         }
                     });
 
                     startPos.x = x;
                     startPos.y = y;
-                    self.resizeControls.update();
+                    self.resizeControls.update(); // redundant update if the position has changed just before
 
                     cy.trigger("noderesize.resizedrag", [location, node]);
                 };

--- a/demo.html
+++ b/demo.html
@@ -8,7 +8,7 @@
 		<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 
 		<script src="https://code.jquery.com/jquery-3.1.0.slim.min.js"></script>
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/ocanvas/2.8.4/ocanvas.min.js"></script>
+		<script src="https://cdn.rawgit.com/konvajs/konva/1.6.3/konva.min.js"></script>
 		<script src="http://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cytoscape.min.js"></script>
 
 		<!-- for testing with local version of cytoscape.js -->

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/iVis-at-Bilkent/cytoscape.js-node-resize/issues"
   },
   "homepage": "https://github.com/iVis-at-Bilkent/cytoscape.js-node-resize",
-  "dependencies": {
+  "peerDependencies": {
     "konva": "^1.6.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "url": "https://github.com/iVis-at-Bilkent/cytoscape.js-node-resize/issues"
   },
   "homepage": "https://github.com/iVis-at-Bilkent/cytoscape.js-node-resize",
+  "dependencies": {
+    "konva": "^1.6.3"
+  },
   "devDependencies": {
     "gulp": "^3.8.8",
     "gulp-jshint": "^1.8.5",

--- a/undoable_demo.html
+++ b/undoable_demo.html
@@ -8,7 +8,7 @@
 		<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 
 		<script src="https://code.jquery.com/jquery-3.1.0.slim.min.js"></script>
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/ocanvas/2.8.4/ocanvas.min.js"></script>
+		<script src="https://cdn.rawgit.com/konvajs/konva/1.6.3/konva.min.js"></script>
 		<script src="http://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cytoscape.min.js"></script>
 		<script src="https://cdn.rawgit.com/ivis-at-bilkent/cytoscape.js-undo-redo/master/cytoscape-undo-redo.js"></script>
 


### PR DESCRIPTION
I replaced oCanvas by Konva (https://konvajs.github.io/), a library with similar capabilities that seems better (doesn't force unwanted redraws), is on npm and has a bigger user base.
The whole extension was refactored to behave according to expectation, which is to minimize redraws and grapples creation. This leads to huge performance improvement. The controls now look 'normal'. They stay in place when resizing.
Control grapples are now class-defined objects with reference to their parent node, which makes them easier to use.

All behavior are kept exactly the same. The difference is the Konva dependency needs to be passed when registering the extension on cytoscape.