### PR TITLE
Support multiple instances

### DIFF
--- a/cytoscape-node-resize.js
+++ b/cytoscape-node-resize.js
@@ -245,108 +245,129 @@
             return;
         }
 
-        var canvas;
+        // var canvas;
+        var stageId = 0;
 
-        var options = {
-            padding: 5, // spacing between node and grapples/rectangle
-            undoable: true, // and if cy.undoRedo exists
+        function defaults () {
+          return {
+              padding: 5, // spacing between node and grapples/rectangle
+              undoable: true, // and if cy.undoRedo exists
 
-            grappleSize: 8, // size of square dots
-            grappleColor: "green", // color of grapples
-            inactiveGrappleStroke: "inside 1px blue",
-            boundingRectangle: true, // enable/disable bounding rectangle
-            boundingRectangleLineDash: [4, 8], // line dash of bounding rectangle
-            boundingRectangleLineColor: "red",
-            boundingRectangleLineWidth: 1.5,
-            zIndex: 999,
+              grappleSize: 8, // size of square dots
+              grappleColor: "green", // color of grapples
+              inactiveGrappleStroke: "inside 1px blue",
+              boundingRectangle: true, // enable/disable bounding rectangle
+              boundingRectangleLineDash: [4, 8], // line dash of bounding rectangle
+              boundingRectangleLineColor: "red",
+              boundingRectangleLineWidth: 1.5,
+              zIndex: 999,
 
-            minWidth: function (node) {
-                var data = node.data("resizeMinWidth");
-                return data ? data : 15;
-            }, // a function returns min width of node
-            minHeight: function (node) {
-                var data = node.data("resizeMinHeight");
-                return data ? data : 15;
-            }, // a function returns min height of node
-            
-            // Getters for some style properties the defaults returns ele.css('property-name')
-            // you are encouraged to override these getters
-            getCompoundMinWidth: function(node) { 
-              return node.css('min-width'); 
-            },
-            getCompoundMinHeight: function(node) { 
-              return node.css('min-height'); 
-            },
-            getCompoundMinWidthBiasRight: function(node) {
-              return node.css('min-width-bias-right');
-            },
-            getCompoundMinWidthBiasLeft: function(node) { 
-              return node.css('min-width-bias-left');
-            },
-            getCompoundMinHeightBiasTop: function(node) {
-              return node.css('min-height-bias-top');
-            },
-            getCompoundMinHeightBiasBottom: function(node) { 
-              return node.css('min-height-bias-bottom');
-            },
-            
-            // These optional function will be executed to set the width/height of a node in this extension
-            // Using node.css() is not a recommended way (http://js.cytoscape.org/#eles.style) to do this. Therefore, overriding these defaults
-            // so that a data field or something like that will be used to set node dimentions instead of directly calling node.css() 
-            // is highly recommended (Of course this will require a proper setting in the stylesheet).
-            setWidth: function(node, width) { 
-                node.css('width', width);
-            },
-            setHeight: function(node, height) {
-                node.css('height', height);
-            },
-            setCompoundMinWidth: function(node, minWidth) { 
-              node.css('min-width', minWidth); 
-            },
-            setCompoundMinHeight: function(node, minHeight) { 
-              node.css('min-height', minHeight); 
-            },
-            setCompoundMinWidthBiasLeft: function(node, minWidthBiasLeft) { 
-              node.css('min-width-bias-left', minWidthBiasLeft); 
-            },
-            setCompoundMinWidthBiasRight: function(node, minHeightBiasRight) {
-              node.css('min-width-bias-right', minHeightBiasRight); 
-            },
-            setCompoundMinHeightBiasTop: function(node, minHeightBiasTop) { 
-              node.css('min-height-bias-top', minHeightBiasTop); 
-            },
-            setCompoundMinHeightBiasBottom: function(node, minHeightBiasBottom) {
-              node.css('min-height-bias-bottom', minHeightBiasBottom); 
-            },
-            
-            isFixedAspectRatioResizeMode: function (node) { return node.is(".fixedAspectRatioResizeMode") },// with only 4 active grapples (at corners)
-            isNoResizeMode: function (node) { return node.is(".noResizeMode, :parent") }, // no active grapples
+              moveSelectedNodesOnKeyEvents: function () {
+                return true;
+              },
 
-            cursors: { // See http://www.w3schools.com/cssref/tryit.asp?filename=trycss_cursor
-                // May take any "cursor" css property
-                default: "default", // to be set after resizing finished or mouseleave
-                inactive: "not-allowed",
-                nw: "nw-resize",
-                n: "n-resize",
-                ne: "ne-resize",
-                e: "e-resize",
-                se: "se-resize",
-                s: "s-resize",
-                sw: "sw-resize",
-                w: "w-resize"
-            }
-        };
-        
-        var api; // The extension api to be exposed 
+              minWidth: function (node) {
+                  var data = node.data("resizeMinWidth");
+                  return data ? data : 15;
+              }, // a function returns min width of node
+              minHeight: function (node) {
+                  var data = node.data("resizeMinHeight");
+                  return data ? data : 15;
+              }, // a function returns min height of node
+
+              // Getters for some style properties the defaults returns ele.css('property-name')
+              // you are encouraged to override these getters
+              getCompoundMinWidth: function(node) {
+                return node.css('min-width');
+              },
+              getCompoundMinHeight: function(node) {
+                return node.css('min-height');
+              },
+              getCompoundMinWidthBiasRight: function(node) {
+                return node.css('min-width-bias-right');
+              },
+              getCompoundMinWidthBiasLeft: function(node) {
+                return node.css('min-width-bias-left');
+              },
+              getCompoundMinHeightBiasTop: function(node) {
+                return node.css('min-height-bias-top');
+              },
+              getCompoundMinHeightBiasBottom: function(node) {
+                return node.css('min-height-bias-bottom');
+              },
+
+              // These optional function will be executed to set the width/height of a node in this extension
+              // Using node.css() is not a recommended way (http://js.cytoscape.org/#eles.style) to do this. Therefore, overriding these defaults
+              // so that a data field or something like that will be used to set node dimentions instead of directly calling node.css()
+              // is highly recommended (Of course this will require a proper setting in the stylesheet).
+              setWidth: function(node, width) {
+                  node.css('width', width);
+              },
+              setHeight: function(node, height) {
+                  node.css('height', height);
+              },
+              setCompoundMinWidth: function(node, minWidth) {
+                node.css('min-width', minWidth);
+              },
+              setCompoundMinHeight: function(node, minHeight) {
+                node.css('min-height', minHeight);
+              },
+              setCompoundMinWidthBiasLeft: function(node, minWidthBiasLeft) {
+                node.css('min-width-bias-left', minWidthBiasLeft);
+              },
+              setCompoundMinWidthBiasRight: function(node, minHeightBiasRight) {
+                node.css('min-width-bias-right', minHeightBiasRight);
+              },
+              setCompoundMinHeightBiasTop: function(node, minHeightBiasTop) {
+                node.css('min-height-bias-top', minHeightBiasTop);
+              },
+              setCompoundMinHeightBiasBottom: function(node, minHeightBiasBottom) {
+                node.css('min-height-bias-bottom', minHeightBiasBottom);
+              },
+
+              isFixedAspectRatioResizeMode: function (node) { return node.is(".fixedAspectRatioResizeMode") },// with only 4 active grapples (at corners)
+              isNoResizeMode: function (node) { return node.is(".noResizeMode, :parent") }, // no active grapples
+
+              cursors: { // See http://www.w3schools.com/cssref/tryit.asp?filename=trycss_cursor
+                  // May take any "cursor" css property
+                  default: "default", // to be set after resizing finished or mouseleave
+                  inactive: "not-allowed",
+                  nw: "nw-resize",
+                  n: "n-resize",
+                  ne: "ne-resize",
+                  e: "e-resize",
+                  se: "se-resize",
+                  s: "s-resize",
+                  sw: "sw-resize",
+                  w: "w-resize"
+              }
+          };
+        }
+
+        // Get the whole scratchpad reserved for this extension (on an element or core) or get a single property of it
+        function getScratch (cyOrEle, name) {
+          if (cyOrEle.scratch('_cyNodeResize') === undefined) {
+            cyOrEle.scratch('_cyNodeResize', {});
+          }
+
+          var scratch = cyOrEle.scratch('_cyNodeResize');
+          var retVal = ( name === undefined ) ? scratch : scratch[name];
+          return retVal;
+        }
+
+        // Set a single property on scratchpad of an element or the core
+        function setScratch (cyOrEle, name, val) {
+          getScratch(cyOrEle)[name] = val;
+        }
 
         cytoscape('core', 'nodeResize', function (opts) {
-            
+
+            var cy = this;
+
             // If options parameter is 'get' string then just return the api
             if (opts === 'get') {
-              return api;
+              return getScratch(cy, 'api');
             }
-            
-            var cy = this;
 
             // the controls object represents the grapples and bounding rectangle
             // only one can exist at any time
@@ -355,19 +376,22 @@
             // Events to bind and unbind
             var eUnselectNode, ePositionNode, eZoom, ePan, eSelectNode, eRemoveNode, eAddNode, eFreeNode, eUndoRedo;
 
-            options = $.extend(true, options, opts);
+            var options = $.extend(true, defaults(), opts);
 
-            var $canvasElement = $('<div id="node-resize"></div>');
+            var canvasElementId = 'cy-node-resize' + stageId;
+            stageId++;
+
+            var $canvasElement = $('<div id="' + canvasElementId + '"></div>');
             var $container = $(cy.container());
             $container.append($canvasElement);
 
             var stage = new Konva.Stage({
-                container: 'node-resize',   // id of container <div>
+                container: canvasElementId,   // id of container <div>
                 width: $container.width(),
                 height: $container.height()
             });
             // then create layer
-            canvas = new Konva.Layer();
+            var canvas = new Konva.Layer();
             // add the layer to the stage
             stage.add(canvas);
 
@@ -935,6 +959,14 @@
 
             var keys = {};
             function keyDown(e) {
+
+                var shouldMove = typeof options.moveSelectedNodesOnKeyEvents === 'function'
+                        ? options.moveSelectedNodesOnKeyEvents() : options.moveSelectedNodesOnKeyEvents;
+
+                if (!shouldMove) {
+                  return;
+                }
+
                 //Checks if the tagname is textarea or input
                 var tn = document.activeElement.tagName;
                 if (tn != "TEXTAREA" && tn != "INPUT")
@@ -1014,6 +1046,13 @@
             function keyUp(e) {
                 if (e.keyCode < '37' || e.keyCode > '40') {
                     return;
+                }
+
+                var shouldMove = typeof options.moveSelectedNodesOnKeyEvents === 'function'
+                        ? options.moveSelectedNodesOnKeyEvents() : options.moveSelectedNodesOnKeyEvents;
+
+                if (!shouldMove) {
+                  return;
                 }
 
                 cy.trigger("noderesize.moveend", [selectedNodesToMove]);
@@ -1285,7 +1324,8 @@
                 cy.undoRedo().action("noderesize.move", moveDo, moveDo);
             }
 
-            api = {}
+            var api = {}; // The extension api to be exposed
+
             api.refreshGrapples = function() {
               if (controls) {
                 // We need to remove old controls and create a new one rather then just updating controls
@@ -1302,6 +1342,9 @@
                 controls = null;
               }
             }
+
+            setScratch(cy, 'api', api);
+
             return api; // Return the api
         });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cytoscape-node-resize",
-  "version": "2.0.9",
+  "version": "3.0.0",
   "description": "",
   "main": "cytoscape-node-resize.js",
   "spm": {


### PR DESCRIPTION
- Enabled working with multiple cytoscape.js instances.

- Added ```moveSelectedNodesOnKeyEvents``` option. It is a dynamic option that is checked on ```keydown``` and ```keyup```  events and disables moving the selected nodes on these events if the check returns a falsey value.
